### PR TITLE
add mask + random mask for atomic targets training

### DIFF
--- a/mace/cli/run_train.py
+++ b/mace/cli/run_train.py
@@ -284,6 +284,7 @@ def run(args: argparse.Namespace) -> None:
                 dipole_key=args.dipole_key,
                 charges_key=args.charges_key,
                 atomic_targets_key=args.atomic_targets_key,
+                atomic_targets_mask_key=args.atomic_targets_mask_key,
                 head_name="pt_head",
                 keep_isolated_atoms=args.keep_isolated_atoms,
             )
@@ -302,6 +303,7 @@ def run(args: argparse.Namespace) -> None:
                 dipole_key=args.dipole_key,
                 charges_key=args.charges_key,
                 atomic_targets_key=args.atomic_targets_key,
+                atomic_targets_mask_key=args.atomic_targets_mask_key,
                 keep_isolated_atoms=args.keep_isolated_atoms,
                 collections=collections,
                 avg_num_neighbors=model_foundation.interactions[0].avg_num_neighbors,

--- a/mace/data/atomic_data.py
+++ b/mace/data/atomic_data.py
@@ -65,6 +65,7 @@ class AtomicData(torch_geometric.data.Data):
         dipole: Optional[torch.Tensor],  # [, 3]
         charges: Optional[torch.Tensor],  # [n_nodes, ]
         atomic_targets: Optional[torch.Tensor], # [n_nodes, ]
+        atomic_targets_mask: Optional[torch.Tensor], # [n_nodes, ]
     ):
         # Check shapes
         num_nodes = node_attrs.shape[0]
@@ -88,6 +89,7 @@ class AtomicData(torch_geometric.data.Data):
         assert dipole is None or dipole.shape[-1] == 3
         assert charges is None or charges.shape == (num_nodes,)
         assert atomic_targets is None or atomic_targets.shape == (num_nodes,)
+        assert atomic_targets_mask is None or atomic_targets_mask.shape == (num_nodes, )
         # Aggregate data
         data = {
             "num_nodes": num_nodes,
@@ -110,6 +112,7 @@ class AtomicData(torch_geometric.data.Data):
             "dipole": dipole,
             "charges": charges,
             "atomic_targets": atomic_targets,
+            "atomic_targets_mask": atomic_targets_mask,
         }
         super().__init__(**data)
 
@@ -214,6 +217,12 @@ class AtomicData(torch_geometric.data.Data):
             else None
         )
 
+        atomic_targets_mask = (
+            torch.tensor(config.atomic_targets_mask, dtype=torch.get_default_dtype())
+            if config.atomic_targets_mask is not None
+            else None
+        )
+
         return cls(
             edge_index=torch.tensor(edge_index, dtype=torch.long),
             positions=torch.tensor(config.positions, dtype=torch.get_default_dtype()),
@@ -234,6 +243,7 @@ class AtomicData(torch_geometric.data.Data):
             dipole=dipole,
             charges=charges,
             atomic_targets=atomic_targets,
+            atomic_targets_mask=atomic_targets_mask,
         )
 
 

--- a/mace/data/utils.py
+++ b/mace/data/utils.py
@@ -40,6 +40,7 @@ class Configuration:
     dipole: Optional[Vector] = None  # Debye
     charges: Optional[Charges] = None  # atomic unit
     atomic_targets: Optional[AtomicTargets] = None
+    atomic_targets_mask: Optional[AtomicTargets] =  None
     cell: Optional[Cell] = None
     pbc: Optional[Pbc] = None
 
@@ -95,6 +96,7 @@ def config_from_atoms_list(
     dipole_key="REF_dipole",
     charges_key="REF_charges",
     atomic_targets_key="REF_atomic_targets",
+    atomic_targets_mask_key="MACE_atomic_targets_mask",
     head_key="head",
     config_type_weights: Optional[Dict[str, float]] = None,
 ) -> Configurations:
@@ -114,6 +116,7 @@ def config_from_atoms_list(
                 dipole_key=dipole_key,
                 charges_key=charges_key,
                 atomic_targets_key=atomic_targets_key,
+                atomic_targets_mask_key=atomic_targets_mask_key,
                 head_key=head_key,
                 config_type_weights=config_type_weights,
             )
@@ -130,6 +133,7 @@ def config_from_atoms(
     dipole_key="REF_dipole",
     charges_key="REF_charges",
     atomic_targets_key="REF_atomic_targets",
+    atomic_targets_mask_key="MACE_atomic_targets_mask",
     head_key="head",
     config_type_weights: Optional[Dict[str, float]] = None,
 ) -> Configuration:
@@ -146,6 +150,9 @@ def config_from_atoms(
     charges = atoms.arrays.get(charges_key, np.zeros(len(atoms)))  # atomic unit
     # Atomic targets default to 0 instead of None if not found
     atomic_targets = atoms.arrays.get(atomic_targets_key, np.zeros(len(atoms)))
+    # Atomic targets default to 1 instead of None if not found
+    atomic_targets_mask = atoms.arrays.get(atomic_targets_mask_key, np.ones(len(atoms)))
+    
     atomic_numbers = np.array(
         [ase.data.atomic_numbers[symbol] for symbol in atoms.symbols]
     )
@@ -189,6 +196,7 @@ def config_from_atoms(
         dipole=dipole,
         charges=charges,
         atomic_targets=atomic_targets,
+        atomic_targets_mask=atomic_targets_mask,
         weight=weight,
         head=head,
         energy_weight=energy_weight,
@@ -228,6 +236,7 @@ def load_from_xyz(
     dipole_key: str = "REF_dipole",
     charges_key: str = "REF_charges",
     atomic_targets_key: str = "REF_atomic_targets",
+    atomic_targets_mask_key: str = "MACE_atomic_targets_mask",
     head_key: str = "head",
     head_name: str = "Default",
     extract_atomic_energies: bool = False,
@@ -307,6 +316,7 @@ def load_from_xyz(
         dipole_key=dipole_key,
         charges_key=charges_key,
         atomic_targets_key=atomic_targets_key,
+        atomic_targets_mask_key=atomic_targets_mask_key,
         head_key=head_key,
     )
     return atomic_energies_dict, configs

--- a/mace/tools/arg_parser.py
+++ b/mace/tools/arg_parser.py
@@ -435,6 +435,33 @@ def build_default_arg_parser() -> argparse.ArgumentParser:
         type=str,
         default="REF_atomic_targets",
     )
+    # masking for atomic_targets
+    parser.add_argument(
+        "--atomic_targets_mask_key",
+        help="key of atomic target mask fitting",
+        default="MACE_atomic_targets_mask",
+    )
+
+    parser.add_argument(
+        "--atomic_targets_mask",
+        help="whether to use mask defined in xyz during fitting",
+        action="store_true",
+        default=True,
+    )
+    
+    parser.add_argument(
+        "--atomic_targets_random_mask",
+        help="whether to use random mask defined in xyz during fitting",
+        action="store_true",
+        default=False,
+    )
+
+    parser.add_argument(
+        "--atomic_targets_random_mask_ratio",
+        help="ratio for random mask for atomic targets",
+        type=float,
+        default=None,
+    )
 
     # Loss and optimization
     parser.add_argument(

--- a/mace/tools/scripts_utils.py
+++ b/mace/tools/scripts_utils.py
@@ -49,6 +49,7 @@ def get_dataset_from_xyz(
     dipole_key: str = "dipoles",
     charges_key: str = "charges",
     atomic_targets_key: str = "atomic_targets",
+    atomic_targets_mask_key: str = "MACE_atomic_targets_mask",
     head_key: str = "head",
 ) -> Tuple[SubsetCollection, Optional[Dict[int, float]]]:
     """Load training and test dataset from xyz file"""
@@ -62,6 +63,7 @@ def get_dataset_from_xyz(
         dipole_key=dipole_key,
         charges_key=charges_key,
         atomic_targets_key=atomic_targets_key,
+        atomic_targets_mask_key=atomic_targets_mask_key,
         head_key=head_key,
         extract_atomic_energies=True,
         keep_isolated_atoms=keep_isolated_atoms,
@@ -81,6 +83,7 @@ def get_dataset_from_xyz(
             dipole_key=dipole_key,
             charges_key=charges_key,
             atomic_targets_key=atomic_targets_key,
+            atomic_targets_mask_key=atomic_targets_mask_key,
             head_key=head_key,
             extract_atomic_energies=False,
             head_name=head_name,
@@ -452,7 +455,7 @@ def get_loss_fn(
     elif args.loss == "atomic_targets":
         assert dipole_only is False and targets_only is True
         loss_fn = modules.AtomicTargetsLoss(
-            huber_delta=args.huber_delta,
+            huber_delta=args.huber_delta, random_mask = args.atomic_targets_random_mask, random_mask_ratio = args.atomic_targets_random_mask_ratio,
         )
     else:
         loss_fn = modules.WeightedEnergyForcesLoss(energy_weight=1.0, forces_weight=1.0)

--- a/train.sh
+++ b/train.sh
@@ -1,0 +1,27 @@
+python scripts/run_train.py \
+    --model="AtomicTargetsMACE" \
+    --num_interactions=2 \
+    --num_channels=32 \
+    --max_L=0 \
+    --correlation=2 \
+    --r_max=2.5 \
+    --max_ell=2 \
+    --loss="atomic_targets" \
+    --error_table="AtomicTargetsPerAtomRMSE" \
+    --name="mace_solvents" \
+    --model_dir="MACE_models" \
+    --log_dir="MACE_models" \
+    --checkpoints_dir="MACE_models" \
+    --results_dir="MACE_models" \
+    --train_file="data/data_substructures27_rc5_periodic_mask.xyz" \
+    --valid_fraction=0.10 \
+    --E0s="average" \
+    --atomic_targets_key="d2min" \
+    --atomic_targets_mask_key="MACE_atomic_targets_mask" \
+    --atomic_targets_random_mask \
+    --atomic_targets_random_mask_ratio=0.8 \
+    --device=cpu \
+    --batch_size=4 \
+    --max_num_epochs=50 \
+    --swa \
+    --seed=123


### PR DESCRIPTION
Adding a few arguments for training atomic targets with mask. See `train.sh` for example.

New arguments:

```bash
--atomic_targets_mask_key="MACE_atomic_targets_mask" \
--atomic_targets_random_mask \
--atomic_targets_random_mask_ratio=0.8 \
```

`atomic_targets_mask_key`: key of mask defined in .xyz file
`atomic_targets_random_mask`: whether to use random mask during training or now, default to`False`
`atomic_targets_random_mask_ratio`: ratio of data (number of nodes) to keep for `atomic_targets_random_mask`, default to None`
